### PR TITLE
Remove require('sys')

### DIFF
--- a/lib/yelp.js
+++ b/lib/yelp.js
@@ -1,6 +1,5 @@
-var sys = require('sys'),
-  querystring = require('querystring'),
-  OAuth = require('oauth').OAuth;
+var querystring = require('querystring');
+var OAuth = require('oauth').OAuth;
 
 var Client = function(oauth_config) {
   this.oauthToken = oauth_config.token;


### PR DESCRIPTION
I removed require('sys') from yelp.js since it is deprecated, and it wasn't being used anyway.  This will prevent the following from showing on the command prompt when you run the demo:

```
The "sys" module is now called "util". It should have a similar interface.
```
